### PR TITLE
Update navigational bar to make it less crowded

### DIFF
--- a/app/assets/index.html
+++ b/app/assets/index.html
@@ -33,14 +33,14 @@
       <div class="container">
         <ul>
           <li><a href="#home">Home</a></li>
-          <li><a href="#map">Map View</a></li>
-          <li><a href="#timeline">Timeline View</a></li>
-          <li><a href="#rankings">Country Rankings</a></li>
+          <li><a href="#map">Map</a></li>
+          <li><a href="#timeline">Timeline</a></li>
+          <li><a href="#rankings">Rankings</a></li>
           <li><a href="#profile">Country Datasheet</a></li>
-          <li><a href="#download">Download Data</a></li>
           <li><a href="#availability">Document Availability</a></li>
           <li><a href="#participation">Public Participation</a></li>
-          <li class="pull-right"><a href="http://internationalbudget.org">Back to IBP site &raquo;</a></li>
+          <li><a href="#download">Download Data</a></li>
+          <li class="pull-right"><a href="http://internationalbudget.org/opening-budgets/open-budget-initiative/open-budget-survey/">IBP Website &raquo;</a></li>
         </ul>
       </div>
     </div>


### PR DESCRIPTION
Shorten navigational items and reorder them a bit to make the
navigational bar a little more accessible and less crowded. Also
put "Download data" last in the site navigation instead of having
it somewhere in the middle because it serves a different purpose
than the other items in the navbar.
